### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,8 @@ jobs:
   quality:
     name: Code Quality Checks
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -62,6 +64,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/10](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/10)

To address the issue, we will add an explicit `permissions` key to both jobs (`quality` and `security`) to limit the `GITHUB_TOKEN` permissions to only those necessary. Based on the tasks performed:
1. For the `quality` job, `contents: read` is sufficient for the checkout step and other operations.
2. For the `security` job, `contents: read` is also sufficient, as it only requires access to the repository's existing files for dependency installation and audit.

The `permissions` key will be added at the job level for both `quality` and `security`. This ensures each job has only the permissions it requires.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
