### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/8](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/8)

To resolve the issue, we will add a `permissions` block to the `Lint Markdown` job to explicitly define the required permissions. Since this job involves only read operations, we will limit permissions to `contents: read`. This ensures that the job has only the access it requires, reducing the risk of unauthorized actions.

The changes will be made in the `.github/workflows/ci.yml` file, specifically in the `lint-markdown` job section. No other jobs or global workflow configurations will be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
