### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,5 +1,9 @@
 name: Performance Tests
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/6](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the root of the workflow configuration. This block will explicitly set the required permissions, limiting access to read-only for repository contents (`contents: read`) and enabling write access only to pull requests (`pull-requests: write`). This adheres to the principle of least privilege and mitigates potential risks associated with excessive permissions.

We will make the following changes:
1. Add a `permissions` block at the root level of the workflow.
2. Specify the required permissions for this workflow: `contents: read` and `pull-requests: write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
