### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: Update Documentation
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/4](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow. This block should be placed at the root level (to apply to all jobs) or within the job itself (to apply specifically to `update-docs`). The permissions should be restricted based on the minimal requirements of the workflow.

For this workflow:
- The `contents: write` permission is needed for the `Checkout repository` and `Commit documentation updates` steps since they involve reading the repository and pushing changes.
- Other permissions (e.g., `issues`, `pull-requests`, etc.) are not required for the current workflow.

The fix will add a `permissions` block with `contents: write` at the workflow root level to ensure the workflow has the required permissions while adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
