### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     needs: test
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/5](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/5)

To address the issue, we need to add an explicit `permissions` block to the `Build` job within the `.github/workflows/ci.yml` file. Based on the job's functionality, the minimal required permission is `contents: read`, as the job only checks out the repository, installs dependencies, builds the package, and uploads artifacts without making any modifications to the repository. This ensures the `GITHUB_TOKEN` has only the permissions necessary to complete the task, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
