### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/examples/basic-examples.html
+++ b/examples/basic-examples.html
@@ -297,6 +297,15 @@
 			}
 
 			// Update custom properties status
+			function escapeHtml(unsafe) {
+				return unsafe
+					.replace(/&/g, "&amp;")
+					.replace(/</g, "&lt;")
+					.replace(/>/g, "&gt;")
+					.replace(/"/g, "&quot;")
+					.replace(/'/g, "&#039;");
+			}
+
 			function updateCustomPropsStatus() {
 				const statusEl = document.getElementById("custom-props-status");
 				const hasSupport = CSS.supports("--custom", "value");
@@ -331,8 +340,8 @@
 				const outputCSS = CSSIfPolyfill.processCSSText(inputCSS);
 
 				outputEl.innerHTML = `
-              <strong>Input:</strong> ${inputCSS}<br>
-              <strong>Output:</strong> ${outputCSS}
+              <strong>Input:</strong> ${escapeHtml(inputCSS)}<br>
+              <strong>Output:</strong> ${escapeHtml(outputCSS)}
           `;
 			};
 


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/2](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/2)

To address this vulnerability, we need to ensure that any text derived from `inputEl.textContent` is properly escaped before being inserted into the DOM as HTML. The best fix is to use a function that encodes special characters into their HTML entity equivalents (`<` -> `&lt;`, `>` -> `&gt;`, etc.) when interpolating text into an HTML template.

1. Add an escaping function to encode meta-characters, which ensures that the text is interpreted literally rather than as HTML.
2. Modify line 333 to use the escaping function for `inputCSS` and `outputCSS` before inserting them into the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
