### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit-fix-pr.yml
+++ b/.github/workflows/audit-fix-pr.yml
@@ -1,5 +1,9 @@
 name: Suggest pnpm audit --fix for Dependabot PRs
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/mfranzke/css-if-polyfill/security/code-scanning/16](https://github.com/mfranzke/css-if-polyfill/security/code-scanning/16)

To fix the problem, you should add a `permissions` key to the workflow file `.github/workflows/audit-fix-pr.yml`. This can be added at the root level (applies to all jobs) or at the job level (applies only to the specific job). The minimal required permissions for this workflow are likely `contents: read` (for checking out code) and `pull-requests: write` (for creating, approving, and merging pull requests). Add the following block near the top of the workflow, after the `name:` and before `on:`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
